### PR TITLE
fix: ドキュメントビューアのAPIルーティングエラーを修正

### DIFF
--- a/openspec/changes/fix-docs-viewer-api-routing/proposal.md
+++ b/openspec/changes/fix-docs-viewer-api-routing/proposal.md
@@ -1,0 +1,41 @@
+# Fix Docs Viewer API Routing
+
+## Summary
+
+Fix the documentation viewer component which is failing to load documentation due to incorrect API routing configuration. The frontend is requesting `/api/docs/*` but receiving HTML instead of JSON because the proxy configuration is not properly set up.
+
+## Problem Statement
+
+The documentation viewer at `http://localhost:5173/docs` shows an error:
+- `SyntaxError: Unexpected token '<', "<!doctype "... is not valid JSON`
+- The viewer shows "MAS Documentation" with "Select an agent to view documentation" but no content loads
+
+Root causes:
+1. The Vite proxy configuration expects `VITE_API_PROXY_TARGET` but `.env.local` provides `VITE_API_BASE`
+2. The API base URL in `.env.local` points to port 3007 but the API server runs on port 8765
+3. Without proper proxy configuration, `/api/docs/*` requests return the index.html fallback instead of being proxied to the backend
+
+## Proposed Solution
+
+1. Update the Vite configuration to recognize both `VITE_API_BASE` and `VITE_API_PROXY_TARGET` for flexibility
+2. Fix the `.env.local` file to point to the correct API port (8765)
+3. Ensure the proxy configuration properly routes `/api/*` requests to the backend server
+
+## User Impact
+
+- Documentation viewer will correctly load and display documentation for agents
+- Users will be able to browse OpenSpec documents through the web interface
+- No breaking changes to existing functionality
+
+## Implementation Approach
+
+The fix involves minimal configuration changes:
+- Update `vite.config.ts` to use `VITE_API_BASE` as fallback for proxy target
+- Correct the port number in `.env.local`
+- No changes needed to backend API routes or frontend components
+
+## Testing Requirements
+
+- Verify documentation structure loads at `/api/docs/structure`
+- Verify agent documents load correctly when selected
+- Confirm no regression in other API endpoints

--- a/openspec/changes/fix-docs-viewer-api-routing/specs/api-proxy-configuration/spec.md
+++ b/openspec/changes/fix-docs-viewer-api-routing/specs/api-proxy-configuration/spec.md
@@ -1,0 +1,43 @@
+# API Proxy Configuration
+
+## MODIFIED Requirements
+
+### Vite Proxy Configuration
+
+The Vite development server proxy configuration MUST support multiple environment variable names for API target configuration.
+
+#### Scenario: Using VITE_API_BASE environment variable
+
+Given the environment variable `VITE_API_BASE=http://localhost:8765`
+When the Vite dev server starts
+Then the proxy configuration should route `/api/*` requests to `http://localhost:8765/*`
+
+#### Scenario: Using VITE_API_PROXY_TARGET environment variable
+
+Given the environment variable `VITE_API_PROXY_TARGET=http://localhost:8765`
+When the Vite dev server starts
+Then the proxy configuration should route `/api/*` requests to `http://localhost:8765/*`
+
+#### Scenario: Priority when both variables are set
+
+Given both `VITE_API_PROXY_TARGET` and `VITE_API_BASE` are set
+When the Vite dev server starts
+Then `VITE_API_PROXY_TARGET` should take precedence over `VITE_API_BASE`
+
+### Environment Configuration
+
+The web application environment configuration MUST correctly specify the API server location.
+
+#### Scenario: Default API server port
+
+Given the MAS API server runs on port 8765 by default
+When configuring the web application environment
+Then the `VITE_API_BASE` should be set to `http://localhost:8765`
+
+#### Scenario: API request routing
+
+Given the frontend makes a request to `/api/docs/structure`
+And the proxy is configured with target `http://localhost:8765`
+When the request is proxied
+Then it should be rewritten to `http://localhost:8765/docs/structure`
+And the response should be JSON, not HTML

--- a/openspec/changes/fix-docs-viewer-api-routing/tasks.md
+++ b/openspec/changes/fix-docs-viewer-api-routing/tasks.md
@@ -1,0 +1,33 @@
+# Tasks
+
+## Implementation Tasks
+
+- [x] **Update Vite configuration to support VITE_API_BASE**
+   - Modify `web/vite.config.ts` to use `VITE_API_BASE` as fallback for proxy target
+   - Maintain backward compatibility with `VITE_API_PROXY_TARGET`
+
+- [x] **Fix API port in environment configuration**
+   - Update `web/.env.local` to use correct API port (8765)
+   - Change from `VITE_API_BASE=http://localhost:3007` to `VITE_API_BASE=http://localhost:8765`
+
+- [x] **Verify proxy configuration**
+   - Test that `/api/docs/structure` correctly proxies to backend
+   - Ensure proxy rewrites `/api/*` to `/*` for backend routing
+
+## Validation Tasks
+
+- [x] **Test documentation viewer functionality**
+   - Start both API server and web dev server
+   - Navigate to `/docs` page
+   - Verify structure loads without JSON parsing errors
+   - Test selecting agents and viewing documents
+
+- [x] **Regression testing**
+   - Verify other API endpoints still work (sessions, messages, etc.)
+   - Ensure no impact to existing functionality
+
+## Documentation Tasks
+
+- [x] **Update environment configuration documentation**
+   - Document the supported environment variables
+   - Add example `.env` file if not present

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,16 @@
+# Vite Development Server Configuration
+# Copy this file to .env.local and adjust values as needed
+
+# Development server port
+VITE_PORT=5173
+
+# API server URL for proxy configuration
+# The Vite dev server will proxy /api/* requests to this URL
+VITE_API_BASE=http://localhost:8765
+
+# HMR (Hot Module Replacement) configuration
+# VITE_HMR_HOST=localhost
+# VITE_HMR_PORT=5173
+
+# Alternative proxy target (takes precedence over VITE_API_BASE if set)
+# VITE_API_PROXY_TARGET=http://localhost:8765

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -25,9 +25,10 @@ export default defineConfig(({ mode }) => {
         port: parseInt(env.VITE_HMR_PORT || '5173')
       } : true,
       // Proxy configuration (optional, configured via environment)
-      proxy: env.VITE_API_PROXY_TARGET ? {
+      // Supports both VITE_API_PROXY_TARGET and VITE_API_BASE
+      proxy: (env.VITE_API_PROXY_TARGET || env.VITE_API_BASE) ? {
         '/api': {
-          target: env.VITE_API_PROXY_TARGET,
+          target: env.VITE_API_PROXY_TARGET || env.VITE_API_BASE,
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/api/, ''),
           secure: false


### PR DESCRIPTION
## 概要
ドキュメントビューア（`/docs`）がJSONパースエラーで動作しない問題を修正しました。

## 問題の詳細
`http://localhost:5173/docs` にアクセスすると以下のエラーが発生していました：
```
SyntaxError: Unexpected token '<', "<!doctype "... is not valid JSON
```

### 原因
1. Viteのプロキシ設定が `VITE_API_PROXY_TARGET` 環境変数を期待していたが、`.env.local` では `VITE_API_BASE` を使用していた
2. `.env.local` のAPIポートが間違っていた（3007 → 8765が正しい）
3. プロキシが正しく設定されていないため、`/api/docs/*` リクエストがバックエンドではなくindex.htmlを返していた

## 変更内容
- ✅ `vite.config.ts` を更新し、`VITE_API_BASE` と `VITE_API_PROXY_TARGET` の両方をサポート
- ✅ `.env.local` のAPIポートを修正（8765に変更）
- ✅ `.env.example` ファイルを追加し、環境変数をドキュメント化
- ✅ OpenSpec提案を作成し、変更を適切に記録

## テスト手順
1. APIサーバーとWebデベロップメントサーバーを起動
2. `http://localhost:5182/docs` にアクセス
3. エラーなしでドキュメント構造が読み込まれることを確認
4. エージェントを選択してドキュメントが表示されることを確認

## 動作確認
- [x] `/api/docs/structure` が正しくJSONを返す
- [x] プロキシが `/api/*` を `/*` に正しく書き換える
- [x] ヘルスチェックなど他のAPIエンドポイントに影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)