### PR TITLE
refactor: アプリケーション名をmas-ui-appからmasに変更

### DIFF
--- a/web/docs/deployment/cloudflare.md
+++ b/web/docs/deployment/cloudflare.md
@@ -25,7 +25,7 @@ wrangler login
 Create a `wrangler.toml` file in your project root:
 
 ```toml
-name = "mas-ui"
+name = "mas"
 compatibility_date = "2025-12-17"
 
 [site]
@@ -264,7 +264,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: mas-ui
+          projectName: mas
           directory: dist
 ```
 

--- a/web/docs/deployment/examples/apache.conf
+++ b/web/docs/deployment/examples/apache.conf
@@ -2,9 +2,9 @@
 # Add this configuration to your Apache virtual host or sites configuration
 
 # Alias for MAS-UI application
-Alias "/mas-ui" "/var/www/mas-ui"  # Replace with your deployment path
+Alias "/mas" "/var/www/mas"  # Replace with your deployment path
 
-<Directory "/var/www/mas-ui">
+<Directory "/var/www/mas">
     Options FollowSymLinks
     AllowOverride None
 
@@ -21,14 +21,14 @@ Alias "/mas-ui" "/var/www/mas-ui"  # Replace with your deployment path
     # SPA (Single Page Application) rewrite rules
     <IfModule mod_rewrite.c>
         RewriteEngine On
-        RewriteBase /mas-ui/
+        RewriteBase /mas/
 
         # Don't rewrite files or directories
         RewriteCond %{REQUEST_FILENAME} !-f
         RewriteCond %{REQUEST_FILENAME} !-d
 
         # Rewrite everything else to index.html for client-side routing
-        RewriteRule . /mas-ui/index.html [L]
+        RewriteRule . /mas/index.html [L]
     </IfModule>
 
     # Cache configuration for static assets

--- a/web/docs/deployment/examples/nginx.conf
+++ b/web/docs/deployment/examples/nginx.conf
@@ -6,7 +6,7 @@ server {
     server_name your-domain.com;  # Replace with your domain
 
     # Root directory for MAS-UI
-    root /var/www/mas-ui;  # Replace with your deployment path
+    root /var/www/mas;  # Replace with your deployment path
     index index.html;
 
     # Main application

--- a/web/docs/deployment/examples/wrangler.json
+++ b/web/docs/deployment/examples/wrangler.json
@@ -1,5 +1,5 @@
 {
-  "name": "mas-ui",
+  "name": "mas",
   "compatibility_date": "2025-12-17",
   "assets": {
     "directory": "./dist"

--- a/web/docs/deployment/vercel.md
+++ b/web/docs/deployment/vercel.md
@@ -19,7 +19,7 @@ npm install -g vercel
 
 2. **Deploy from your project directory:**
 ```bash
-cd mas-ui
+cd mas
 vercel
 ```
 

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>mas-ui-app</title>
+    <title>mas</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## 概要
アプリケーション全体で一貫した命名規則を実現するため、アプリケーション名を「mas-ui-app」から「mas」に変更しました。

## 変更理由
現在、アプリケーションは以下のような不統一な命名を使用していました：
- HTMLタイトルには「mas-ui-app」を表示
- パッケージ名は「@mas/web」と「@frexida/mas」を使用
- ドキュメントとデプロイメント例では「mas-ui」を参照

この変更により、ユーザーが目にする要素とドキュメント全体で「mas」という簡潔で統一された名前を使用します。

## 変更内容
### ✅ 更新されたファイル（6ファイル）
- `web/index.html` - ブラウザタイトルを「mas」に更新
- `web/docs/deployment/cloudflare.md` - Wrangler設定とGitHub Actionsの例を更新
- `web/docs/deployment/vercel.md` - ディレクトリ例を更新
- `web/docs/deployment/examples/wrangler.json` - プロジェクト名を更新
- `web/docs/deployment/examples/nginx.conf` - ルートディレクトリパスを更新
- `web/docs/deployment/examples/apache.conf` - Alias、Directory、RewriteBase、RewriteRuleを更新

## 影響範囲
- **ユーザーへの影響**: ブラウザタブに「mas」と表示されます（従来は「mas-ui-app」）
- **技術的影響**: コードの変更なし、依存関係への影響なし
- **リスク**: 低 - 表示とドキュメントの変更のみ

## テスト手順
- [x] 開発サーバーを起動してブラウザタイトルが「mas」と表示されることを確認
- [x] すべてのドキュメント変更の一貫性を確認
- [x] 設定例の構文が有効であることを確認
- [x] アクティブなドキュメントに「mas-ui」への参照が残っていないことを確認（アーカイブを除く）

## 補足
- `ARCHIVED_BRANCHES.md`の歴史的参照は意図的に保持しています
- パッケージ名は既に正しい名前空間（@mas/web、@frexida/mas）を使用しているため変更不要です

🤖 Generated with [Claude Code](https://claude.com/claude-code)